### PR TITLE
workaround to show tray icon

### DIFF
--- a/telegram.desktop
+++ b/telegram.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Telegram
 GenericName=Telegram Messenger
-Exec=/usr/bin/telegram-desktop -- %u
+Exec=env GDK_BACKEND=x11 /usr/bin/telegram-desktop -- %u
 Terminal=false
 StartupWMClass=telegram-desktop
 Icon=telegram-desktop


### PR DESCRIPTION
This is a workaround to fix missing tray icon in GNOME Shell.

https://bugzilla.redhat.com/show_bug.cgi?id=1389875